### PR TITLE
Cookie entry (updating logs)

### DIFF
--- a/include/inventory.hpp
+++ b/include/inventory.hpp
@@ -22,6 +22,7 @@ protected:
 
 private slots:
     void onAddLogClicked();
+    void onCookieButtonClicked();
     void onSpreadsheetImportClicked();
 
 private:

--- a/include/logs.hpp
+++ b/include/logs.hpp
@@ -62,6 +62,7 @@ public:
 
     // Scraps a log
     void scrap();
+    void cut_length(uint amt);
 
     // Required by Persistent
     int get_id() const override {return id;}
@@ -69,7 +70,6 @@ public:
     bool update() override;
     static std::optional<Log> get_by_id(int id); 
     static std::vector<Log> get_all();
-    static std::optional<Log> cut_length(int id, uint amt);
 };
 
 #endif // TYPES_HPP

--- a/include/logs.hpp
+++ b/include/logs.hpp
@@ -69,6 +69,7 @@ public:
     bool update() override;
     static std::optional<Log> get_by_id(int id); 
     static std::vector<Log> get_all();
+    static std::optional<Log> cut_length(int id, uint amt);
 };
 
 #endif // TYPES_HPP

--- a/src/cookies.cpp
+++ b/src/cookies.cpp
@@ -23,15 +23,6 @@
 //      media               BLOB
 // );
 
-/* Still Need (3/25/25):
-- Cookie GUI (wait for GUI update)
-- Handling of cookie thickness via user input (done in mainwindow.cpp)
-*/
-
-/* Errors:
--  
-*/
-
 Cookie::Cookie(
     int id,
     int from_log,
@@ -131,37 +122,6 @@ std::vector<Cookie> Cookie::make_from_log(
     std::vector<Cookie> cookie;
     // ID, Log ID, Thickness, Diameter, Drying
     cookie.push_back(Cookie(0, log.get_id(), log.getSpecies(), thickness_quarters, log.getDiameterQuarters(), drying.value_or(Drying::KILN_DRIED)));
-    // ID, species, length
-    // Likely just update log when the button is clicked and after the dialog is used
-    //log.push_back(Log(0, log.get_id(), log.getSpecies()), log.getLenQuarters - thickness_quarters - 0.75));
-
+    
     return cookie;
 }
-/*
-void MainWindow::onCookieButtonClicked() {
-    // Get the selected log id
-    std::optional<Log> opt = Log::get_by_id(ui->individualLogTableView->currentIndex().siblingAtColumn(0).data().toInt());
-
-    if (!opt) {
-        QMessageBox::critical(this, "Error", "Log not found");
-        return;
-    }
-
-    Log log = opt.value();
-
-    // Dialog for the user to enter a uint for cookie thickness
-    // https://doc.qt.io/qt-5/qinputdialog.html
-    // Pointer, Dialog Title, Dialog Text, Initial Val, Min Val, Max Val, Trigger Val
-    bool ok;    
-    int enteredCut = QInputDialog::getInt(this, QObject::tr("Cookie Cutter"), QObject::tr("Please enter the desired cookie thickness:"), 0.01, 0.01, log.getLenQuarters(), &accept);     
-
-    if(ok && !enteredCut.isEmpty()) {
-        std::cout << "Cutting Cookie!" << std::endl;
-        unsigned int cutDepth = static_cast<unsigned int>(enteredCut);
-
-        auto cookie = Cookie::make_from_log(log, cutDepth);
-    } else { std::cout << "User canceled input." << std::endl; }
-
-    refreshModel();
-}
-*/

--- a/src/cookies.cpp
+++ b/src/cookies.cpp
@@ -130,8 +130,10 @@ std::vector<Cookie> Cookie::make_from_log(
 ) {
     std::vector<Cookie> cookie;
     // ID, Log ID, Thickness, Diameter, Drying
-
     cookie.push_back(Cookie(0, log.get_id(), log.getSpecies(), thickness_quarters, log.getDiameterQuarters(), drying.value_or(Drying::KILN_DRIED)));
+    // ID, species, length
+    // Likely just update log when the button is clicked and after the dialog is used
+    //log.push_back(Log(0, log.get_id(), log.getSpecies()), log.getLenQuarters - thickness_quarters - 0.75));
 
     return cookie;
 }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -104,17 +104,17 @@ void InventoryPage::onCookieButtonClicked() {
     // https://doc.qt.io/qt-5/qinputdialog.html
     // Pointer, Dialog Title, Dialog Text, Initial Val, Min Val, Max Val, Trigger Val
     bool ok;    
-    int enteredCut = QInputDialog::getInt(this, QObject::tr("Cookie Cutter"), QObject::tr("Please enter the desired cookie thickness:"), 0.01, 0.01, log.getLenQuarters(), ok);     
-    int bladeWidth = 0.125; // Replace with non-hard-coded blade width once UI for it is complete
+    int enteredCut = QInputDialog::getInt(this, QObject::tr("Cookie Cutter"), QObject::tr("Please enter the desired cookie thickness (inches):"), 0.01, 0.01, log.getLenQuarters(), ok);     
+    //int bladeWidth = 0.125; // Replace with non-hard-coded blade width once UI for it is complete
 
-    if(ok) {
+    if(!ok) {
         std::cout << "Cutting Cookie!" << std::endl;
         //unsigned int cutDepth = static_cast<unsigned int>(enteredCut);
-        int newLogLength = log.getLenQuarters() - enteredCut - bladeWidth;
+        //int newLogLength = log.getLenQuarters() - enteredCut - bladeWidth;
 
         auto cookie = Cookie::make_from_log(log, static_cast<unsigned int>(enteredCut));
-        log(0, log.getSpecies(), newLogLength);
-        log.update();
+        log.cut_length(static_cast<unsigned int>(enteredCut));
+
     } else { std::cout << "User canceled input." << std::endl; }
 
     refreshModels();

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -8,10 +8,12 @@
 #include <QScreen>
 #include <QMouseEvent>
 #include <QTimer>
+#include <QInputDialog>
 
 #include "inventory.hpp"
 #include "ui_inventory.h"
 #include "logs.hpp"
+#include "cookies.hpp"
 
 InventoryPage::InventoryPage(QWidget *parent)
     : QWidget(parent)
@@ -40,6 +42,7 @@ InventoryPage::InventoryPage(QWidget *parent)
 
     connect(ui->addLogButton, &QPushButton::clicked, this, &InventoryPage::onAddLogClicked);
     connect(ui->spreadsheetImporterButton, &QPushButton::clicked, this, &InventoryPage::onSpreadsheetImportClicked);
+    connect(ui->createCookieButton, &QPushButton::clicked, this, &InventoryPage::onCookieButtonClicked);
 
     setFocusPolicy(Qt::StrongFocus);
     setWindowTitle("Inventory Management");
@@ -82,6 +85,37 @@ void InventoryPage::onAddLogClicked()
 
     Log log(0, species.toStdString(), lenQuarters, diamQuarters, costQuarters, quality, location);
     log.insert();
+
+    refreshModels();
+}
+
+void InventoryPage::onCookieButtonClicked() {
+    // Get the selected log id
+    std::optional<Log> opt = Log::get_by_id(ui->individualLogsTable->currentIndex().siblingAtColumn(0).data().toInt());
+
+    if (!opt) {
+        QMessageBox::critical(this, "Error", "Log not found");
+        return;
+    }
+
+    Log log = opt.value();
+
+    // Dialog for the user to enter a uint for cookie thickness
+    // https://doc.qt.io/qt-5/qinputdialog.html
+    // Pointer, Dialog Title, Dialog Text, Initial Val, Min Val, Max Val, Trigger Val
+    bool ok;    
+    int enteredCut = QInputDialog::getInt(this, QObject::tr("Cookie Cutter"), QObject::tr("Please enter the desired cookie thickness:"), 0.01, 0.01, log.getLenQuarters(), ok);     
+    int bladeWidth = 0.125; // Replace with non-hard-coded blade width once UI for it is complete
+
+    if(ok) {
+        std::cout << "Cutting Cookie!" << std::endl;
+        //unsigned int cutDepth = static_cast<unsigned int>(enteredCut);
+        int newLogLength = log.getLenQuarters() - enteredCut - bladeWidth;
+
+        auto cookie = Cookie::make_from_log(log, static_cast<unsigned int>(enteredCut));
+        log(0, log.getSpecies(), newLogLength);
+        log.update();
+    } else { std::cout << "User canceled input." << std::endl; }
 
     refreshModels();
 }

--- a/src/logs.cpp
+++ b/src/logs.cpp
@@ -127,6 +127,17 @@ std::vector<Log> Log::get_all() {
     return logs;
 }
 
+std::vector<Log> Log::cut_length(int id, uint amt) {
+    std::vector<Log> log;
+    
+    // Remove given length from given log
+
+    // Update log
+
+    return log;
+}
+
+
 void Log::scrap() {
     // Set the scrapped column to 1 in the database
     SQLite::Database db(DATABASE_FILE, SQLite::OPEN_READWRITE);

--- a/src/logs.cpp
+++ b/src/logs.cpp
@@ -127,14 +127,11 @@ std::vector<Log> Log::get_all() {
     return logs;
 }
 
-std::vector<Log> Log::cut_length(int id, uint amt) {
-    std::vector<Log> log;
-    
-    // Remove given length from given log
-
-    // Update log
-
-    return log;
+void Log::cut_length(uint amt) {
+    //Remove length from Log
+    this->len_quarters -= amt + 0.125;
+    // Update Log
+    Log::update();
 }
 
 

--- a/ui/inventory.ui
+++ b/ui/inventory.ui
@@ -1,210 +1,196 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>InventoryPage</class>
-    <widget class="QWidget" name="InventoryPage">
-        <property name="windowTitle">
-            <string>Inventory Management</string>
+ <class>InventoryPage</class>
+ <widget class="QWidget" name="InventoryPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>988</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>600</width>
+    <height>400</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Inventory Management</string>
+  </property>
+  <layout class="QVBoxLayout" name="mainLayout">
+   <item>
+    <widget class="QGroupBox" name="logEntryPanel">
+     <property name="title">
+      <string>Log Entry Panel</string>
+     </property>
+     <layout class="QGridLayout" name="logEntryLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="speciesLabel">
+        <property name="text">
+         <string>Species:</string>
         </property>
-        <property name="geometry">
-            <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>800</width>
-                <height>600</height>
-            </rect>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="speciesEntry"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lengthFtLabel">
+        <property name="text">
+         <string>Length (ft):</string>
         </property>
-        <property name="minimumSize">
-            <size>
-                <width>600</width>
-                <height>400</height>
-            </size>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="lengthFt"/>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="lengthInLabel">
+        <property name="text">
+         <string>Inches:</string>
         </property>
-        <layout class="QVBoxLayout" name="mainLayout">
-
-            <!-- Log Entry Panel -->
-            <item>
-                <widget class="QGroupBox" name="logEntryPanel">
-                    <property name="title">
-                        <string>Log Entry Panel</string>
-                    </property>
-                    <layout class="QGridLayout" name="logEntryLayout">
-
-                        <item row="0" column="0">
-                            <widget class="QLabel" name="speciesLabel">
-                                <property name="text">
-                                    <string>Species:</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="0" column="1">
-                            <widget class="QLineEdit" name="speciesEntry" />
-                        </item>
-
-                        <item row="1" column="0">
-                            <widget class="QLabel" name="lengthFtLabel">
-                                <property name="text">
-                                    <string>Length (ft):</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="1" column="1">
-                            <widget class="QSpinBox" name="lengthFt" />
-                        </item>
-
-                        <item row="1" column="2">
-                            <widget class="QLabel" name="lengthInLabel">
-                                <property name="text">
-                                    <string>Inches:</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="1" column="3">
-                            <widget class="QSpinBox" name="lengthIn" />
-                        </item>
-
-                        <item row="2" column="0">
-                            <widget class="QLabel" name="diameterLabel">
-                                <property name="text">
-                                    <string>Diameter (in):</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="2" column="1">
-                            <widget class="QSpinBox" name="diameterIn" />
-                        </item>
-
-                        <item row="3" column="0">
-                            <widget class="QLabel" name="costLabel">
-                                <property name="text">
-                                    <string>Cost ($):</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="3" column="1">
-                            <widget class="QDoubleSpinBox" name="costValue" />
-                        </item>
-
-                        <item row="4" column="0">
-                            <widget class="QLabel" name="qualityLabel">
-                                <property name="text">
-                                    <string>Quality (1–10):</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="4" column="1">
-                            <widget class="QSpinBox" name="qualityValue">
-                                <property name="maximum">
-                                    <number>10</number>
-                                </property>
-                            </widget>
-                        </item>
-
-                        <item row="5" column="0">
-                            <widget class="QLabel" name="locationLabel">
-                                <property name="text">
-                                    <string>Location:</string>
-                                </property>
-                            </widget>
-                        </item>
-                        <item row="5" column="1" colspan="3">
-                            <widget class="QLineEdit" name="locationEntry" />
-                        </item>
-
-                        <item row="6" column="0" colspan="4">
-                            <widget class="QPushButton" name="addLogButton">
-                                <property name="text">
-                                    <string>Add Log</string>
-                                </property>
-                            </widget>
-                        </item>
-
-                    </layout>
-                </widget>
-            </item>
-
-            <!-- Tables side-by-side -->
-            <item>
-                <layout class="QHBoxLayout" name="tablesLayout">
-
-                    <!-- Individual Logs -->
-                    <item>
-                        <widget class="QTableView" name="individualLogsTable">
-                            <property name="selectionBehavior">
-                                <enum>QAbstractItemView::SelectRows</enum>
-                            </property>
-                            <property name="selectionMode">
-                                <enum>QAbstractItemView::SingleSelection</enum>
-                            </property>
-                            <property name="horizontalScrollMode">
-                                <enum>QAbstractItemView::ScrollPerPixel</enum>
-                            </property>
-                            <property name="verticalScrollMode">
-                                <enum>QAbstractItemView::ScrollPerPixel</enum>
-                            </property>
-                            <property name="showGrid">
-                                <bool>true</bool>
-                            </property>
-                            <attribute name="horizontalHeaderStretchLastSection">
-                                <bool>true</bool>
-                            </attribute>
-                        </widget>
-                    </item>
-
-                    <!-- Grouped Logs -->
-                    <item>
-                        <widget class="QTableView" name="groupedLogsTable">
-                            <property name="selectionBehavior">
-                                <enum>QAbstractItemView::SelectRows</enum>
-                            </property>
-                            <property name="selectionMode">
-                                <enum>QAbstractItemView::SingleSelection</enum>
-                            </property>
-                            <property name="horizontalScrollMode">
-                                <enum>QAbstractItemView::ScrollPerPixel</enum>
-                            </property>
-                            <property name="verticalScrollMode">
-                                <enum>QAbstractItemView::ScrollPerPixel</enum>
-                            </property>
-                            <property name="showGrid">
-                                <bool>true</bool>
-                            </property>
-                            <attribute name="horizontalHeaderStretchLastSection">
-                                <bool>true</bool>
-                            </attribute>
-                        </widget>
-                    </item>
-
-                </layout>
-            </item>
-
-            <!-- Import Button -->
-            <item>
-                <layout class="QHBoxLayout" name="importLayout">
-                    <item>
-                        <spacer name="horizontalSpacer">
-                            <property name="orientation">
-                                <enum>Qt::Horizontal</enum>
-                            </property>
-                            <property name="sizeHint" stdset="0">
-                                <size>
-                                    <width>40</width>
-                                    <height>20</height>
-                                </size>
-                            </property>
-                        </spacer>
-                    </item>
-                    <item>
-                        <widget class="QPushButton" name="spreadsheetImporterButton">
-                            <property name="text">
-                                <string>Import from Spreadsheet...</string>
-                            </property>
-                        </widget>
-                    </item>
-                </layout>
-            </item>
-
-        </layout>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QSpinBox" name="lengthIn"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="diameterLabel">
+        <property name="text">
+         <string>Diameter (in):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="diameterIn"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="costLabel">
+        <property name="text">
+         <string>Cost ($):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QDoubleSpinBox" name="costValue"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="qualityLabel">
+        <property name="text">
+         <string>Quality (1–5):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="qualityValue">
+        <property name="maximum">
+         <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="locationLabel">
+        <property name="text">
+         <string>Location:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="3">
+       <widget class="QLineEdit" name="locationEntry"/>
+      </item>
+      <item row="6" column="0" colspan="3">
+       <widget class="QPushButton" name="addLogButton">
+        <property name="text">
+         <string>Add Log</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="3">
+       <widget class="QPushButton" name="createCookieButton">
+        <property name="text">
+         <string>Create Cookie</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-    <resources />
-    <connections />
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="tablesLayout">
+     <item>
+      <widget class="QTableView" name="individualLogsTable">
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
+       <property name="horizontalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
+       <property name="showGrid">
+        <bool>true</bool>
+       </property>
+       <attribute name="horizontalHeaderStretchLastSection">
+        <bool>true</bool>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QTableView" name="groupedLogsTable">
+       <property name="selectionMode">
+        <enum>QAbstractItemView::SingleSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
+       <property name="horizontalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
+       <property name="showGrid">
+        <bool>true</bool>
+       </property>
+       <attribute name="horizontalHeaderStretchLastSection">
+        <bool>true</bool>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="importLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="spreadsheetImporterButton">
+       <property name="text">
+        <string>Import from Spreadsheet...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
1x Merge w/Main
1x Minor comment update

Cookies Changes:
- Removed theoretical comments for inventory page
  - Code moved to inventory page
  
Inventory Changes:
- Created createCookieButton
- Hooked Cookie Button to its slot
  - Slot SHOULD create dialog for user to input the desired cookie length
  - Slot will also call to a log function to update the log, removing the input length + the (currently hardcoded) blade's width (0.125 inch)
  
Update to log files:
- Added cut_length function
  - Takes in a uint, removes that amount + 0.125 from the log and updates the log
  
Update to inventory file:
- Now updates log when cutting a cookie from it
  - Calculations MIGHT be wrong. Easily fixable later, functionality is more important
- Added "(inches)" to user input dialog


Remaining To-Do:
- Fix Inventory Page GUI to show all products, not just logs